### PR TITLE
feat(database): Phase 0 schema migrations

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,96 @@
+# Database
+
+PostgreSQL 17. All schema changes are plain SQL migrations in `migrations/`, applied in filename order.
+
+No extensions are required for Phase 0. `gen_random_uuid()` is a PostgreSQL built-in (v13+). pgvector is added in the Phase 3 migration when semantic search is introduced.
+
+---
+
+## Schema
+
+```
+┌─────────────────────────────────┐
+│         family_members          │
+├─────────────────────────────────┤
+│ id              UUID       PK   │
+│ name            VARCHAR(100) NN │
+│ completed_tours JSONB  NN  '{}'│
+│ created_at      TIMESTAMPTZ NN  │
+│ updated_at      TIMESTAMPTZ NN  │
+└─────────────────────────────────┘
+             │
+             │ added_by  FK  ON DELETE SET NULL
+             ▼
+┌─────────────────────────────────┐
+│            recipes              │
+├─────────────────────────────────┤
+│ id         UUID        PK       │
+│ rating     SMALLINT NN (0–3)    │
+│ added_by   UUID     FK nullable │
+│ notes      TEXT                 │
+│ created_at TIMESTAMPTZ NN       │
+│ updated_at TIMESTAMPTZ NN       │
+└─────────────────────────────────┘
+
+Indexes
+  idx_recipes_created_at_desc  ON recipes(created_at DESC)
+  idx_recipes_added_by         ON recipes(added_by) WHERE added_by IS NOT NULL
+```
+
+Columns for future phases are added in their own migrations, not pre-declared here:
+
+| Column | Table | Added in |
+|--------|-------|----------|
+| `raw_metadata JSONB` | recipes | Phase 1 (import worker) |
+| `ingredients JSONB` | recipes | Phase 1 (import worker) |
+| `embedding VECTOR(1536)` | recipes | Phase 3 (semantic search) |
+
+---
+
+## Migration Files
+
+| File | Contents |
+|------|----------|
+| `001_initial_schema.sql` | `family_members`, `recipes` |
+| `002_add_indexes.sql` | List and FK indexes |
+
+---
+
+## Running Migrations Manually
+
+```bash
+# Against a running container
+docker compose exec postgres \
+  psql -U postgres -d recipes \
+  -f /path/to/database/migrations/001_initial_schema.sql
+
+# Via connection string from the host
+psql "$POSTGRES_CONNECTION_STRING" -f database/migrations/001_initial_schema.sql
+psql "$POSTGRES_CONNECTION_STRING" -f database/migrations/002_add_indexes.sql
+```
+
+Both files are idempotent — re-running them is safe.
+
+---
+
+## Auto-run on API Startup
+
+The .NET API applies all `database/migrations/*.sql` files in filename order at
+startup, before accepting traffic. Files already recorded in the internal
+`_migrations` table are skipped. No manual migration step is needed after
+`docker compose up`.
+
+---
+
+## Rollback
+
+Migrations are forward-only. There are no down scripts.
+
+**Development** — recreate from scratch:
+```bash
+docker compose down -v   # destroys the postgres volume
+docker compose up        # schema recreated on next startup
+```
+
+**Staging / production** — write a new forward migration that undoes the change
+and deploy it normally.

--- a/database/migrations/001_initial_schema.sql
+++ b/database/migrations/001_initial_schema.sql
@@ -1,0 +1,37 @@
+-- =============================================================================
+-- Migration 001: Initial Schema
+-- Phase 0 MVP — family_members and recipes tables
+--
+-- Idempotent: safe to run multiple times (uses IF NOT EXISTS throughout).
+-- Compatible with: PostgreSQL 17, Flyway, Entity Framework migrations runner.
+--
+-- No extensions required. gen_random_uuid() is a PostgreSQL built-in since v13.
+-- pgvector and additional columns are added in their respective phase migrations.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Table: family_members
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS family_members (
+    id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    name            VARCHAR(100) NOT NULL,
+    -- JSON object tracking which onboarding hint tours this member has dismissed.
+    -- e.g. { "capture": true, "planner": true }
+    completed_tours JSONB        NOT NULL DEFAULT '{}',
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- ---------------------------------------------------------------------------
+-- Table: recipes
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS recipes (
+    id         UUID     PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- 4-point rating scale: 0=Unknown 1=Dislike 2=Like 3=Love
+    rating     SMALLINT NOT NULL CHECK (rating >= 0 AND rating <= 3),
+    -- NULL when the capturing family member has since been deleted.
+    added_by   UUID     REFERENCES family_members(id) ON DELETE SET NULL,
+    notes      TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/database/migrations/002_add_indexes.sql
+++ b/database/migrations/002_add_indexes.sql
@@ -1,0 +1,17 @@
+-- =============================================================================
+-- Migration 002: Performance Indexes
+-- Phase 0 MVP — indexes for active query patterns only
+--
+-- Idempotent: safe to run multiple times (uses IF NOT EXISTS throughout).
+-- Run after 001_initial_schema.sql.
+-- =============================================================================
+
+-- GET /api/recipes orders by created_at DESC with LIMIT/OFFSET pagination.
+CREATE INDEX IF NOT EXISTS idx_recipes_created_at_desc
+    ON recipes (created_at DESC);
+
+-- Speeds up ON DELETE SET NULL cascade when a family member is deleted,
+-- and any future "filter by member" queries.
+CREATE INDEX IF NOT EXISTS idx_recipes_added_by
+    ON recipes (added_by)
+    WHERE added_by IS NOT NULL;


### PR DESCRIPTION
## Summary

- Adds `database/migrations/001_initial_schema.sql` — `family_members` and `recipes` tables for Phase 0 MVP
- Adds `database/migrations/002_add_indexes.sql` — `created_at DESC` and `added_by` partial indexes
- Adds `database/README.md` — schema diagram, manual run steps, auto-run explanation, rollback strategy

## What changed and why

**No extensions.** The original draft included `uuid-ossp`, but `gen_random_uuid()` has been a PostgreSQL built-in since v13. Removed.

**No forward-compatibility columns.** `embedding VECTOR(1536)`, `raw_metadata JSONB`, and `ingredients JSONB` were removed from the Phase 0 schema. They belong in the Phase 1 / Phase 3 migrations that introduce the code that actually uses them. Carrying dead nullable columns forward is the definition of pulling technical debt forward.

**Minimal, correct schema for what Phase 0 actually does:**
- `family_members`: identity + onboarding tour tracking
- `recipes`: captured rating, who added it, optional notes
- Both migrations are fully idempotent (`IF NOT EXISTS` throughout)

## Reviewer notes

- `completed_tours JSONB NOT NULL DEFAULT '{}'` is on `family_members` — this is a Phase 0 feature (hint tour dismissal state per member)
- The `added_by` FK uses `ON DELETE SET NULL` so recipes survive family member deletion
- The partial index `WHERE added_by IS NOT NULL` avoids indexing NULLs after deletions
- pgvector extension and `embedding` column will be added in the Phase 3 migration alongside the semantic search code