### PR TITLE
fix: prevent syncRecipe() from overwriting optimistic GOTO confirm state

### DIFF
--- a/pwa/e2e/home-goto.spec.ts
+++ b/pwa/e2e/home-goto.spec.ts
@@ -92,6 +92,76 @@ test.describe('Home Command Center — GOTO & Pivot Flow', () => {
     await confirmBtn.click();
 
     await expect.poll(() => assignCalled).toBe(true);
+    await expect(page.getByTestId('tonight-menu-card')).toBeVisible({ timeout: 3000 });
+    await expect(page.getByTestId('tonight-pivot-card')).not.toBeVisible();
+  });
+
+  test('Menu card stays after GOTO confirm when schedule re-sync returns empty', async ({
+    page,
+  }) => {
+    // Regression test for: optimistic setCurrentRecipe being overwritten by syncRecipe()
+    // completing after the confirm click with an empty schedule response.
+
+    // 1. Mock schedule to always return empty (simulates the race where the in-flight
+    //    syncRecipe() hasn't seen the assignment yet when it completes)
+    await page.route(/\/(?:backend\/)?api\/schedule(?:\?.*)?$/, async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: { weekOffset: 0, days: [] } }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    // 2. Mock GOTO setting
+    await page.route(/\/(?:backend\/)?api\/settings\/family_goto/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            key: 'family_goto',
+            value: {
+              description: 'Family GOTO',
+              recipeId: MOCK_IDS.RECIPE_LASAGNA,
+            },
+          },
+        }),
+      });
+    });
+
+    // 3. Mock GOTO status as ready
+    await page.route(/\/(?:backend\/)?api\/recipes\/[0-9a-f-]+\/status/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: { id: MOCK_IDS.RECIPE_LASAGNA, status: 'ready' } }),
+      });
+    });
+
+    // 4. Mock assign to resolve immediately
+    await page.route(/\/(?:backend\/)?api\/schedule\/assign/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+    });
+
+    await page.goto('/home');
+    const confirmBtn = page.getByTestId('confirm-goto-btn');
+    await expect(confirmBtn).toBeEnabled({ timeout: 10000 });
+    await confirmBtn.click();
+
+    // Menu card must appear despite syncRecipe() getting an empty schedule
+    await expect(page.getByTestId('tonight-menu-card')).toBeVisible({ timeout: 3000 });
+    // Wait out any re-sync window to confirm the card does not flicker back
+    await page.waitForTimeout(2000);
+    await expect(page.getByTestId('tonight-menu-card')).toBeVisible();
+    await expect(page.getByTestId('tonight-pivot-card')).not.toBeVisible();
   });
 
   test('Pending GOTO polls until ready', async ({ page }) => {

--- a/pwa/src/components/home/HomeCommandCenter.tsx
+++ b/pwa/src/components/home/HomeCommandCenter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { QuickCaptureTrigger, CookedSuccessCard } from './HomeSections';
 import { TonightMenuCard } from './TonightMenuCard';
 import { TonightPivotCard } from './TonightPivotCard';
@@ -39,6 +39,7 @@ export function HomeCommandCenter({ todaysRecipe }: HomeCommandCenterProps) {
   const [gotoRecipeStatus, setGotoRecipeStatus] = useState<'pending' | 'ready' | null>(null);
   const [gotoRecipeData, setGotoRecipeData] = useState<any>(null);
   const [isLoading, setIsLoading] = useState(!todaysRecipe); // Show loader only when SSR had nothing
+  const pendingConfirmRef = useRef(false);
   const router = useRouter();
   const { loadSetting, saveSetting, familySettings } = useFamilyStore();
 
@@ -129,7 +130,7 @@ export function HomeCommandCenter({ todaysRecipe }: HomeCommandCenterProps) {
             const recipe = todaysEntry.recipe;
             const unwrapped = 'data' in recipe ? recipe.data : recipe;
             setCurrentRecipe(unwrapped);
-          } else {
+          } else if (!pendingConfirmRef.current) {
             setCurrentRecipe(null);
           }
         } catch (error) {
@@ -268,6 +269,7 @@ export function HomeCommandCenter({ todaysRecipe }: HomeCommandCenterProps) {
                     ingredients: gotoRecipeData?.ingredients,
                   };
 
+                  pendingConfirmRef.current = true;
                   setCurrentRecipe(optimisticRecipe);
                   const dayIndex = (new Date().getDay() + 6) % 7;
                   assignRecipeToDay(0, dayIndex, {
@@ -276,7 +278,8 @@ export function HomeCommandCenter({ todaysRecipe }: HomeCommandCenterProps) {
                     image: optimisticRecipe.image ?? '',
                   })
                     .then(() => router.refresh())
-                    .catch((err) => console.error('Failed to confirm GOTO:', err));
+                    .catch((err) => console.error('Failed to confirm GOTO:', err))
+                    .finally(() => { pendingConfirmRef.current = false; });
                 } else {
                   setShowQuickFind(true);
                 }


### PR DESCRIPTION
When the user clicks "Confirm GOTO", an in-flight syncRecipe() call (started
on mount) could complete after the optimistic setCurrentRecipe() and set
currentRecipe back to null — causing the pivot card to re-appear indefinitely.

Adds a pendingConfirmRef guard so syncRecipe() skips the null-clear while an
assign is in-flight. Also extends the home-goto e2e tests with post-confirm
UI assertions and a dedicated regression test that keeps the schedule mock
returning empty throughout, directly exercising the race condition.

https://claude.ai/code/session_01UQ85PZDkCKixVNfLAotF18