### PR TITLE
fix: pass recipeId in move.post and reset state on drop in recovery flow

### DIFF
--- a/pwa/e2e/home-recipe.spec.ts
+++ b/pwa/e2e/home-recipe.spec.ts
@@ -511,11 +511,13 @@ test.describe('Home Command Center — Planned Recipe Flow', () => {
           assignCalled = true;
           await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
         } else if (url.pathname.endsWith('/api/schedule') && method === 'GET') {
+          // Before drop: today still has the recipe so sync() doesn't clobber the SSE-seeded store.
+          // After drop: today is empty so sync() reflects the removed slot.
           const days = Array.from({ length: 7 }, (_, i) => {
             const d = new Date(monday);
             d.setUTCDate(monday.getUTCDate() + i);
             const dateStr = toDateStr(d);
-            return { date: dateStr, status: 0, recipe: null };
+            return { date: dateStr, status: 0, recipe: dateStr === today && !removeCalled ? lasagnaRecipe : null };
           });
           await route.fulfill({
             status: 200,

--- a/pwa/e2e/home-recipe.spec.ts
+++ b/pwa/e2e/home-recipe.spec.ts
@@ -287,6 +287,7 @@ test.describe('Home Command Center — Planned Recipe Flow', () => {
     });
 
     let moveCalled = false;
+    let moveRecipeId: string | null = null;
     let assignCalled = false;
 
     await mockSseWithSlotUpdate(page, { date: today, recipe: lasagnaRecipe, status: 0 });
@@ -315,6 +316,8 @@ test.describe('Home Command Center — Planned Recipe Flow', () => {
           });
         } else if (url.pathname.endsWith('/move') && method === 'POST') {
           moveCalled = true;
+          const body = request.postDataJSON();
+          moveRecipeId = body?.recipeId ?? null;
           await route.fulfill({
             status: 200,
             contentType: 'application/json',
@@ -380,12 +383,187 @@ test.describe('Home Command Center — Planned Recipe Flow', () => {
     // Click "Move to Tomorrow"
     await page.getByTestId('recovery-action-tomorrow').click();
 
-    // Verify both APIs called
+    // Verify both APIs called and move sent the correct recipeId (regression: BS-10)
     await expect.poll(() => moveCalled).toBe(true);
     await expect.poll(() => assignCalled).toBe(true);
+    expect(moveRecipeId).toBe(MOCK_IDS.RECIPE_LASAGNA);
 
     // Dialog should be closed
     await expect(page.getByTestId('recovery-dialog-title')).not.toBeVisible();
+  });
+
+  test('"Order In → Move to Tomorrow" sends recipeId and closes dialog', async ({ page }) => {
+    const monday = currentMonday();
+    const today = toDateStr(monday);
+    const lasagnaRecipe = builders.scheduleRecipe({
+      id: MOCK_IDS.RECIPE_LASAGNA,
+      name: 'Test Lasagna',
+      image: `/api/recipes/${MOCK_IDS.RECIPE_LASAGNA}/hero`,
+    });
+
+    let moveCalled = false;
+    let moveRecipeId: string | null = null;
+
+    await mockSseWithSlotUpdate(page, { date: today, recipe: lasagnaRecipe, status: 0 });
+
+    await page.route(
+      (url) => url.pathname.includes('/api/schedule'),
+      async (route) => {
+        const request = route.request();
+        const url = new URL(request.url());
+        const method = request.method();
+
+        if (url.pathname.endsWith('/move') && method === 'POST') {
+          moveCalled = true;
+          const body = request.postDataJSON();
+          moveRecipeId = body?.recipeId ?? null;
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ data: { message: 'Recipe moved' } }),
+          });
+        } else if (url.pathname.endsWith('/api/schedule') && method === 'GET') {
+          const days = Array.from({ length: 7 }, (_, i) => {
+            const d = new Date(monday);
+            d.setUTCDate(monday.getUTCDate() + i);
+            const dateStr = toDateStr(d);
+            return { date: dateStr, status: 0, recipe: dateStr === today ? lasagnaRecipe : null };
+          });
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ data: { weekOffset: 0, days } }),
+          });
+        } else {
+          await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+        }
+      }
+    );
+
+    await page.goto('/home');
+    await expect(page.getByTestId('home-loader')).not.toBeVisible();
+    await expect(page.getByTestId('tonight-menu-card')).toBeVisible();
+
+    // Flip the card and click skip
+    await page.getByTestId('tonight-menu-card').click();
+    await page.waitForTimeout(600);
+    await page.evaluate(() => {
+      const btn = document.querySelector('[data-testid="skip-tonight-btn"]') as HTMLElement;
+      btn?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+
+    await expect(page.getByTestId('recovery-dialog-title')).toBeVisible();
+
+    // Click "Ordering In" → step 2
+    await page.getByTestId('recovery-action-order-in').click();
+    await expect(page.getByText("What about tonight's recipe?")).toBeVisible();
+
+    // Click "Move to Tomorrow"
+    await page.getByTestId('recovery-action-tomorrow').click();
+
+    // Move must be called with the original recipe's ID (regression: BS-10)
+    await expect.poll(() => moveCalled).toBe(true);
+    expect(moveRecipeId).toBe(MOCK_IDS.RECIPE_LASAGNA);
+
+    // Dialog must be closed
+    await expect(page.getByTestId('recovery-dialog-title')).not.toBeVisible();
+  });
+
+  test('"Order In → Drop Tonight" resets state so user can re-plan', async ({ page }) => {
+    const monday = currentMonday();
+    const today = toDateStr(monday);
+    const lasagnaRecipe = builders.scheduleRecipe({
+      id: MOCK_IDS.RECIPE_LASAGNA,
+      name: 'Test Lasagna',
+      image: `/api/recipes/${MOCK_IDS.RECIPE_LASAGNA}/hero`,
+    });
+
+    let removeCalled = false;
+    let assignCalled = false;
+
+    await mockSseWithSlotUpdate(page, { date: today, recipe: lasagnaRecipe, status: 0 });
+
+    await page.route(
+      (url) => url.pathname.includes('/api/schedule'),
+      async (route) => {
+        const request = route.request();
+        const url = new URL(request.url());
+        const method = request.method();
+
+        if (url.pathname.endsWith('/fill-the-gap')) {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              data: [
+                builders.scheduleRecipe({
+                  id: MOCK_IDS.RECIPE_CHICKEN,
+                  name: 'Test Chicken',
+                  image: '/chicken.jpg',
+                }),
+              ],
+            }),
+          });
+        } else if (url.pathname.includes('/day/') && url.pathname.endsWith('/remove') && method === 'DELETE') {
+          removeCalled = true;
+          await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+        } else if (url.pathname.endsWith('/assign') && method === 'POST') {
+          assignCalled = true;
+          await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+        } else if (url.pathname.endsWith('/api/schedule') && method === 'GET') {
+          const days = Array.from({ length: 7 }, (_, i) => {
+            const d = new Date(monday);
+            d.setUTCDate(monday.getUTCDate() + i);
+            const dateStr = toDateStr(d);
+            return { date: dateStr, status: 0, recipe: null };
+          });
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ data: { weekOffset: 0, days } }),
+          });
+        } else {
+          await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+        }
+      }
+    );
+
+    await page.goto('/home');
+    await expect(page.getByTestId('home-loader')).not.toBeVisible();
+    await expect(page.getByTestId('tonight-menu-card')).toBeVisible();
+
+    // Flip the card and click skip
+    await page.getByTestId('tonight-menu-card').click();
+    await page.waitForTimeout(600);
+    await page.evaluate(() => {
+      const btn = document.querySelector('[data-testid="skip-tonight-btn"]') as HTMLElement;
+      btn?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+
+    await expect(page.getByTestId('recovery-dialog-title')).toBeVisible();
+
+    // Click "Ordering In" → step 2
+    await page.getByTestId('recovery-action-order-in').click();
+    await expect(page.getByText("What about tonight's recipe?")).toBeVisible();
+
+    // Click "Just Drop Tonight"
+    await page.getByText('Just Drop Tonight').click();
+
+    // Remove must be called
+    await expect.poll(() => removeCalled).toBe(true);
+
+    // Dialog must be closed
+    await expect(page.getByTestId('recovery-dialog-title')).not.toBeVisible();
+
+    // Pivot card must show — user is NOT stuck (regression: drop resets status)
+    await expect(page.getByTestId('tonight-pivot-card')).toBeVisible({ timeout: 3000 });
+
+    // User can add a recipe back via Quick Find
+    await page.getByTestId('discover-btn').click();
+    await expect(page.getByTestId('quick-find-modal')).toBeVisible();
+    await page.getByTestId('quick-find-select').first().click();
+    await expect(page.getByTestId('tonight-menu-card')).toBeVisible({ timeout: 500 });
+    await expect.poll(() => assignCalled).toBe(true);
   });
 
   test('Closing Quick Find after "Pick Something Else" exits without changing tonight', async ({

--- a/pwa/src/components/home/HomeCommandCenter.tsx
+++ b/pwa/src/components/home/HomeCommandCenter.tsx
@@ -213,12 +213,18 @@ export function HomeCommandCenter({ todaysRecipe, todayStatus }: HomeCommandCent
         } else if (action === 'pick_else') {
           setRecoveryFlow({ kind: 'quick_find', intent: 'pick_else' });
         } else if (action === 'tomorrow') {
+          const recipeId = currentRecipe?.id;
+          if (!recipeId) {
+            setRecoveryFlow({ kind: 'closed' });
+            return;
+          }
           // Reschedule tonight's meal to tomorrow
           await apiClient.api.schedule.move.post({
             weekOffset: 0,
             fromIndex: (new Date().getDay() + 6) % 7,
             toIndex: ((new Date().getDay() + 6) % 7) + 1,
             intent: 'push',
+            recipeId,
           });
 
           if (recoveryFlow.kind === 'step2' && recoveryFlow.intent === 'pick_else') {
@@ -228,12 +234,18 @@ export function HomeCommandCenter({ todaysRecipe, todayStatus }: HomeCommandCent
           setRecoveryFlow({ kind: 'closed' });
           sync();
         } else if (action === 'next_week') {
+          const recipeId = currentRecipe?.id;
+          if (!recipeId) {
+            setRecoveryFlow({ kind: 'closed' });
+            return;
+          }
           await apiClient.api.schedule.move.post({
             weekOffset: 0,
             fromIndex: (new Date().getDay() + 6) % 7,
             toIndex: 0,
             targetWeekOffset: 1,
             intent: 'push',
+            recipeId,
           });
           if (recoveryFlow.kind === 'step2' && recoveryFlow.intent === 'pick_else') {
             assignRecipe(recoveryFlow.pendingRecipe);
@@ -242,6 +254,8 @@ export function HomeCommandCenter({ todaysRecipe, todayStatus }: HomeCommandCent
           sync();
         } else if (action === 'drop') {
           await apiClient.api.schedule.day.byDate(todayDate).remove.delete();
+          // Reset today's slot so the user can re-plan after dropping
+          useTodayStore.getState().applyServerUpdate({ recipe: null, status: 0 });
           if (recoveryFlow.kind === 'step2' && recoveryFlow.intent === 'pick_else') {
             assignRecipe(recoveryFlow.pendingRecipe);
           }
@@ -252,7 +266,7 @@ export function HomeCommandCenter({ todaysRecipe, todayStatus }: HomeCommandCent
         console.error('Failed recovery action:', error);
       }
     },
-    [markOrderedIn, sync, recoveryFlow, assignRecipe]
+    [markOrderedIn, sync, recoveryFlow, assignRecipe, currentRecipe]
   );
 
   const handleQuickFindSelect = async (recipe: any) => {


### PR DESCRIPTION
After BS-10, the backend's MoveScheduleEventAsync looks up the CalendarEvent
by RecipeId instead of FromIndex. The recovery flow was never updated to pass
recipeId, so every "Move to Tomorrow" and "Save for Next Week" action silently
did nothing (backend found no event with Guid.Empty and returned 200).

- Pass currentRecipe.id as recipeId in both move.post calls (tomorrow, next_week)
- Guard against null currentRecipe (closes dialog early if somehow null)
- Add currentRecipe to useCallback deps so the closure is always fresh
- After the drop action, call applyServerUpdate({recipe:null,status:0}) to
  reset today's store state so the user can re-plan instead of being stuck
  with a sessionDone=true state from the prior markOrderedIn optimistic write

E2E tests updated to assert recipeId is present in the move request body and
that drop resets to TonightPivotCard so a recipe can be added back.

https://claude.ai/code/session_014E5tf5NL2kV5b8ipZ8Y1D8