### PR TITLE
fix: make Cook's Mode render as a true fullscreen overlay

### DIFF
--- a/pwa/src/components/planner/CooksMode.tsx
+++ b/pwa/src/components/planner/CooksMode.tsx
@@ -70,6 +70,13 @@ export function CooksMode({ recipe: initialRecipe, onClose, onCooked }: CooksMod
   const currentStep = cookProgress[initialRecipe.id] ?? 0;
 
   useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  useEffect(() => {
     const fetchDetails = async () => {
       try {
         const details = await getRecipe(initialRecipe.id);
@@ -132,7 +139,7 @@ export function CooksMode({ recipe: initialRecipe, onClose, onCooked }: CooksMod
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       data-testid="cooks-mode-overlay"
-      className="fixed inset-0 z-[100] bg-cream flex flex-col relative"
+      className="fixed inset-0 z-[100] bg-cream flex flex-col"
     >
       <AnimatePresence>
         {showCelebration && (

--- a/pwa/src/components/planner/CooksMode.tsx
+++ b/pwa/src/components/planner/CooksMode.tsx
@@ -70,9 +70,10 @@ export function CooksMode({ recipe: initialRecipe, onClose, onCooked }: CooksMod
   const currentStep = cookProgress[initialRecipe.id] ?? 0;
 
   useEffect(() => {
+    const previous = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
     return () => {
-      document.body.style.overflow = '';
+      document.body.style.overflow = previous;
     };
   }, []);
 


### PR DESCRIPTION
The outer motion.div had both `fixed` and `relative` in its className.
In Tailwind's generated CSS, `.relative` appears after `.fixed` (same
specificity, later declaration wins), so `relative` silently overrode
`fixed` and the overlay rendered in normal document flow instead of
covering the viewport.

Also adds a body scroll-lock effect so the background page cannot be
scrolled while Cook's Mode is open.

https://claude.ai/code/session_01LUWn1yKprvBfDaMsK9YRmh