### PR TITLE
Remove green pulse animation on meal slot recipe removal

### DIFF
--- a/pwa/src/app/(app)/planner/page.tsx
+++ b/pwa/src/app/(app)/planner/page.tsx
@@ -197,8 +197,6 @@ export default function PlannerPage() {
     const date = schedule[dayIndex].date;
     if (!date) return;
     useWeekStore.getState().removeRecipe(dayIndex, date);
-    setSuccessDay(dayIndex);
-    setTimeout(() => setSuccessDay(null), 2000);
     setShowPivot(null);
   };
 


### PR DESCRIPTION
The success ring animation was firing on both recipe assignment and removal.
Assignment (via URL params) still triggers the pulse; removal no longer does.

https://claude.ai/code/session_01QLFfVvkP2xezWKPTYXys3q