### PR TITLE
fix: push grocery list via SSE after recompute and improve empty state

### DIFF
--- a/api/src/RecipeApi/Services/ScheduleService.cs
+++ b/api/src/RecipeApi/Services/ScheduleService.cs
@@ -294,6 +294,9 @@ public class ScheduleService(RecipeDbContext dbContext, ILogger<ScheduleService>
 
         await _groceryRecomputeService.RecomputeForWeekAsync(monday, CancellationToken.None);
 
+        var updatedSchedule = await GetScheduleAsync(dto.WeekOffset);
+        await _publisher.PublishWeekUpdatedAsync(updatedSchedule, excludeConnectionId);
+
         // Build the ScheduleRecipeDto for the assigned slot
         var assignedEvent = await _dbContext.CalendarEvents
             .Include(e => e.Recipe)
@@ -391,6 +394,9 @@ public class ScheduleService(RecipeDbContext dbContext, ILogger<ScheduleService>
             _logger.LogInformation("Removed recipe from date {Date}", date);
 
             await _groceryRecomputeService.RecomputeForWeekAsync(monday, CancellationToken.None);
+
+            var updatedSchedule = await GetScheduleAsync(weekOffset);
+            await _publisher.PublishWeekUpdatedAsync(updatedSchedule, excludeConnectionId);
 
             await _publisher.PublishSlotUpdatedAsync(date, null, 0, excludeConnectionId);
             await _publisher.PublishFillTheGapInvalidatedAsync(weekOffset, excludeConnectionId);

--- a/pwa/src/components/planner/GroceryList.tsx
+++ b/pwa/src/components/planner/GroceryList.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { useEffect, useMemo, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { AlertCircle, CheckCircle2, Circle, Tag } from 'lucide-react';
+import { AlertCircle, CheckCircle2, Circle, Tag, ShoppingCart } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { usePlannerStore } from '@/store/plannerStore';
 import { t, tWithVars } from '@/locales';
@@ -154,13 +154,32 @@ export function GroceryList({ weekOffset, items, onClose }: GroceryListProps) {
           <AnimatePresence mode="wait">
             {Object.keys(grouped).length === 0 ? (
               <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                className="text-center py-12"
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="text-center py-16 px-4"
+                data-testid="grocery-empty-state"
               >
-                <p className="text-charcoal/40 font-medium">
-                  {t('grocery.noIngredients', "No ingredients in this week's plan")}
+                <div className="mx-auto mb-6 h-20 w-20 rounded-full bg-sage/10 flex items-center justify-center">
+                  <ShoppingCart size={36} className="text-sage/50" />
+                </div>
+                <h3 className="font-heading text-xl font-black text-charcoal mb-2">
+                  {t('grocery.emptyTitle', 'Your list is empty')}
+                </h3>
+                <p className="text-charcoal/50 text-sm font-medium max-w-xs mx-auto mb-8 leading-relaxed">
+                  {t(
+                    'grocery.emptyBody',
+                    'Add meals to your planner and your grocery list will build itself — organized by store section.'
+                  )}
                 </p>
+                {onClose && (
+                  <Button
+                    onClick={onClose}
+                    data-testid="grocery-empty-go-to-planner"
+                    className="rounded-3xl bg-sage text-white px-8 h-14 text-sm font-bold shadow-lg shadow-sage/20"
+                  >
+                    {t('grocery.goToPlanner', 'Go to Planner')}
+                  </Button>
+                )}
               </motion.div>
             ) : (
               <div className="space-y-8">


### PR DESCRIPTION
After assigning or removing a recipe, the server now broadcasts week_updated
via SSE immediately after RecomputeForWeekAsync — matching the pattern used
by OpenVotingAsync and LockScheduleAsync. Clients receive the recomputed
groceryItems in real-time without requiring a page reload or waiting for the
10-second sync window.

Replaces the dead-end "No ingredients" text in GroceryList with a purposeful
zero-state card: ShoppingCart icon, headline, explanation, and a "Go to Planner"
CTA that routes users to the next logical step.

https://claude.ai/code/session_012sCf84DhwF1WmgoxQU6Bw8