### PR TITLE
fix: queue React state updates before Zustand call in handleRemoveRecipe

### DIFF
--- a/pwa/src/app/(app)/planner/page.tsx
+++ b/pwa/src/app/(app)/planner/page.tsx
@@ -196,10 +196,10 @@ export default function PlannerPage() {
     const dayIndex = showPivot.dayIndex;
     const date = schedule[dayIndex].date;
     if (!date) return;
-    useWeekStore.getState().removeRecipe(dayIndex, date);
     setSuccessDay(dayIndex);
     setTimeout(() => setSuccessDay(null), 2000);
     setShowPivot(null);
+    useWeekStore.getState().removeRecipe(dayIndex, date);
   };
 
   // Framer Motion calls onReorder on every pointer move during drag (fires on each midpoint


### PR DESCRIPTION
In React 18, calling useWeekStore.getState().removeRecipe() first can trigger a useSyncExternalStore-driven re-render before React processes the batched setSuccessDay/setShowPivot updates. In that intermediate render successDay is still null, so AnimatePresence never mounts the success-ring element.

Moving the Zustand call to the end of the handler ensures the React state updates are in the queue first. The optimistic store update is still fire-and-forget and no API timing is changed.

https://claude.ai/code/session_01LUWn1yKprvBfDaMsK9YRmh