### PR TITLE
fix: cycle through all voting categories before showing empty state on discovery

### DIFF
--- a/pwa/e2e/discovery.spec.ts
+++ b/pwa/e2e/discovery.spec.ts
@@ -153,6 +153,162 @@ test.describe('Discovery Flow', () => {
     await expect(page.getByTestId('just-planned-badge')).not.toBeVisible({ timeout: 5_000 });
   });
 
+  test('should auto-advance past empty first category to next non-empty category', async ({
+    page,
+  }) => {
+    // Italian is empty (all voted), Asian has cards — page should land on Asian, not empty state
+    await page.route(
+      (url) => url.pathname.endsWith('/api/discovery') && !url.pathname.includes('/vote'),
+      async (route) => {
+        const category = new URL(route.request().url()).searchParams.get('category');
+        if (category === 'Italian') {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ data: [] }),
+          });
+        } else {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ data: MOCK_STACK }),
+          });
+        }
+      }
+    );
+
+    await page.goto('/discovery');
+
+    await expect(page.getByTestId('discovery-loader')).not.toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('discovery-card').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('discovery-empty-state')).not.toBeVisible();
+  });
+
+  test('should skip multiple empty categories before showing first non-empty category', async ({
+    page,
+  }) => {
+    // Italian and Asian are empty, Mexican has cards
+    await page.route(
+      (url) => url.pathname.endsWith('/api/discovery') && !url.pathname.includes('/vote'),
+      async (route) => {
+        const category = new URL(route.request().url()).searchParams.get('category');
+        if (category === 'Italian' || category === 'Asian') {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ data: [] }),
+          });
+        } else {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ data: MOCK_STACK }),
+          });
+        }
+      }
+    );
+
+    await page.goto('/discovery');
+
+    await expect(page.getByTestId('discovery-loader')).not.toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('discovery-card').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('discovery-empty-state')).not.toBeVisible();
+  });
+
+  test('refresh button should be hidden while voting categories are available', async ({
+    page,
+  }) => {
+    await page.goto('/discovery');
+
+    await expect(page.getByTestId('discovery-loader')).not.toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('discovery-card').first()).toBeVisible({ timeout: 10_000 });
+
+    // Refresh button must not be rendered while cards are present
+    await expect(page.getByTestId('refresh-button')).not.toBeVisible();
+  });
+
+  test('refresh button should appear only after all categories are exhausted', async ({ page }) => {
+    await page.goto('/discovery');
+
+    await expect(page.getByTestId('discovery-loader')).not.toBeVisible({ timeout: 15_000 });
+
+    // 3 categories × 2 cards = 6 swipes to exhaust everything
+    for (let i = 0; i < 6; i++) {
+      const likeBtn = page.getByTestId('like-button');
+      await expect(likeBtn).toBeEnabled({ timeout: 5_000 });
+      await likeBtn.click();
+    }
+
+    await expect(page.getByTestId('discovery-empty-state')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('refresh-button')).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('SSE fill_the_gap empties last card in category → auto-advances to next category', async ({
+    page,
+  }) => {
+    await mockSseWithFillTheGapInvalidated(page, 0);
+
+    // Italian has 1 card (Lasagna). After SSE, Italian refetch returns [] — Lasagna was planned.
+    // The next category (Asian/Mexican) uses a DISTINCT stack with no "Mock Gourmet Discovery"
+    // so the assertion that Lasagna disappears is reliable even across SSE reconnects.
+    const NEXT_STACK = [
+      builders.recipe({ id: MOCK_IDS.RECIPE_CARBONARA, name: 'Mock Comfort Classic' }),
+      builders.recipe({ id: MOCK_IDS.RECIPE_CHICKEN, name: 'Mock Chicken Delight' }),
+    ];
+
+    let italianCallCount = 0;
+    await page.route(
+      (url) => url.pathname.endsWith('/api/discovery') && !url.pathname.includes('/vote'),
+      async (route) => {
+        const category = new URL(route.request().url()).searchParams.get('category');
+        if (category === 'Italian') {
+          const idx = italianCallCount++;
+          if (idx === 0) {
+            // Initial load: 1 card
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify({
+                data: [builders.recipe({ id: MOCK_IDS.RECIPE_LASAGNA, name: 'Mock Gourmet Discovery' })],
+              }),
+            });
+          } else {
+            // Silent refetch after SSE: Lasagna was planned
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify({ data: [] }),
+            });
+          }
+        } else {
+          // Asian / Mexican — always return the distinct next-category stack
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ data: NEXT_STACK }),
+          });
+        }
+      }
+    );
+
+    await page.goto('/discovery');
+
+    await expect(page.getByTestId('discovery-loader')).not.toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('discovery-card').first()).toBeVisible();
+
+    // After SSE fires and the refetch empties Italian, the page auto-advances.
+    // Lasagna should disappear and be replaced by next-category cards.
+    await expect(
+      page.locator('[data-testid="discovery-card"]').filter({ hasText: /Mock Gourmet Discovery/i })
+    ).not.toBeVisible({ timeout: 10_000 });
+
+    // Empty state must NOT appear — we cycled to the next category
+    await expect(page.getByTestId('discovery-empty-state')).not.toBeVisible({ timeout: 5_000 });
+
+    // A card from the next category should be visible
+    await expect(page.getByTestId('discovery-card').first()).toBeVisible({ timeout: 10_000 });
+  });
+
   test('SSE vote_updated: ring appears on voted card; position-0 card unchanged', async ({
     page,
   }) => {

--- a/pwa/e2e/discovery.spec.ts
+++ b/pwa/e2e/discovery.spec.ts
@@ -81,6 +81,24 @@ test.describe('Discovery Flow', () => {
   });
 
   test('should swipe through all categories and show summary', async ({ page }) => {
+    // Each category returns MOCK_STACK on the first fetch (initial load / loadNextCategory),
+    // then [] on subsequent fetches — simulating that all recipes in that category were voted.
+    // Without this, the wrap-around in loadNextCategory would re-serve already-visited categories.
+    const categoryServed = new Set<string>();
+    await page.route(
+      (url) => url.pathname.endsWith('/api/discovery') && !url.pathname.includes('/vote'),
+      async (route) => {
+        const category = new URL(route.request().url()).searchParams.get('category') ?? '';
+        const firstTime = !categoryServed.has(category);
+        categoryServed.add(category);
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: firstTime ? MOCK_STACK : [] }),
+        });
+      }
+    );
+
     await page.goto('/discovery');
 
     await expect(page.getByTestId('discovery-loader')).not.toBeVisible({ timeout: 15_000 });
@@ -228,6 +246,23 @@ test.describe('Discovery Flow', () => {
   });
 
   test('refresh button should appear only after all categories are exhausted', async ({ page }) => {
+    // Same "first-serve only" mock as the summary test — wrap-around must not
+    // re-serve already-voted categories and prevent the empty state from appearing.
+    const categoryServed = new Set<string>();
+    await page.route(
+      (url) => url.pathname.endsWith('/api/discovery') && !url.pathname.includes('/vote'),
+      async (route) => {
+        const category = new URL(route.request().url()).searchParams.get('category') ?? '';
+        const firstTime = !categoryServed.has(category);
+        categoryServed.add(category);
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: firstTime ? MOCK_STACK : [] }),
+        });
+      }
+    );
+
     await page.goto('/discovery');
 
     await expect(page.getByTestId('discovery-loader')).not.toBeVisible({ timeout: 15_000 });

--- a/pwa/src/app/(app)/discovery/page.tsx
+++ b/pwa/src/app/(app)/discovery/page.tsx
@@ -11,7 +11,7 @@ import { useFamily } from '@/hooks/useFamily';
 import { t, tWithVars } from '@/locales';
 
 export default function DiscoveryPage() {
-  const { setHasPendingCards, activeCategory, setActiveCategory } = useDiscoveryStore();
+  const { setHasPendingCards, setActiveCategory } = useDiscoveryStore();
   // Lift state to store — SSE can now update the stack without the page being mounted
   const recipes = useDiscoveryStore((s) => s.discoveryStack);
   const fillTheGapVersion = useDiscoveryStore((s) => s.fillTheGapVersion);
@@ -77,9 +77,16 @@ export default function DiscoveryPage() {
 
         // Nudge priority: read activeCategory from store at call-time (not from
         // the closure dep) so we don't re-trigger this effect when we set it below.
-        const storedCategory = useDiscoveryStore.getState().activeCategory;
-        const targetCategory = storedCategory ?? cats[0];
-        if (targetCategory) {
+        if (cats.length === 0) {
+          if (!ignore) {
+            setActiveCategory(null);
+            categoryIndexRef.current = 0;
+            useDiscoveryStore.getState().setStack([]);
+            stackIsLoadedRef.current = true;
+          }
+        } else {
+          const storedCategory = useDiscoveryStore.getState().activeCategory;
+          const targetCategory = storedCategory ?? cats[0];
           const index = cats.indexOf(targetCategory);
           const resolvedIndex = index !== -1 ? index : 0;
 

--- a/pwa/src/app/(app)/discovery/page.tsx
+++ b/pwa/src/app/(app)/discovery/page.tsx
@@ -16,8 +16,6 @@ export default function DiscoveryPage() {
   const recipes = useDiscoveryStore((s) => s.discoveryStack);
   const fillTheGapVersion = useDiscoveryStore((s) => s.fillTheGapVersion);
   const { selectedFamilyMemberId, _hasHydrated } = useFamily();
-  const [categories, setCategories] = useState<string[]>([]);
-  const [currentCategoryIndex, setCurrentCategoryIndex] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [isEureka, setIsEureka] = useState(false);
   const [matchCount, setMatchCount] = useState(0);
@@ -36,9 +34,7 @@ export default function DiscoveryPage() {
     setIsLoading(true);
     try {
       const cats = await getCategories();
-      setCategories(cats);
       categoriesRef.current = cats;
-      setCurrentCategoryIndex(0);
       categoryIndexRef.current = 0;
 
       let startIndex = 0;
@@ -48,7 +44,6 @@ export default function DiscoveryPage() {
         const stack = await getDiscoveryStack(categoryToLoad);
         if (stack.length > 0) {
           setActiveCategory(categoryToLoad);
-          setCurrentCategoryIndex(startIndex);
           categoryIndexRef.current = startIndex;
           useDiscoveryStore.getState().setStack(
             stack.map((r) => ({ ...r, imageUrl: `/api/recipes/${r.id}/hero` }))
@@ -77,7 +72,6 @@ export default function DiscoveryPage() {
       try {
         const cats = await getCategories();
         if (ignore) return;
-        setCategories(cats);
         categoriesRef.current = cats;
 
         // Nudge priority: read activeCategory from store at call-time (not from
@@ -95,7 +89,6 @@ export default function DiscoveryPage() {
             const stack = await getDiscoveryStack(categoryToLoad);
             if (ignore) break;
             if (stack.length > 0) {
-              setCurrentCategoryIndex(startIndex);
               categoryIndexRef.current = startIndex;
               setActiveCategory(categoryToLoad);
               useDiscoveryStore.getState().setStack(
@@ -108,6 +101,8 @@ export default function DiscoveryPage() {
             startIndex++;
           }
           if (!foundNonEmpty && !ignore) {
+            setActiveCategory(null);
+            categoryIndexRef.current = 0;
             useDiscoveryStore.getState().setStack([]);
             stackIsLoadedRef.current = true;
           }
@@ -149,7 +144,6 @@ export default function DiscoveryPage() {
             imageUrl: `/api/recipes/${r.id}/hero`,
           }));
           useDiscoveryStore.getState().setStack(mappedStack);
-          setCurrentCategoryIndex(nextIndex);
           categoryIndexRef.current = nextIndex;
           setActiveCategory(nextCategory);
           return;
@@ -157,6 +151,8 @@ export default function DiscoveryPage() {
         nextIndex++;
       }
       // All remaining categories exhausted → show empty state
+      setActiveCategory(null);
+      categoryIndexRef.current = 0;
       useDiscoveryStore.getState().setStack([]);
     } catch (error) {
       console.error('Failed to fetch next category stack', error);

--- a/pwa/src/app/(app)/discovery/page.tsx
+++ b/pwa/src/app/(app)/discovery/page.tsx
@@ -37,25 +37,26 @@ export default function DiscoveryPage() {
       categoriesRef.current = cats;
       categoryIndexRef.current = 0;
 
-      let startIndex = 0;
       let foundNonEmpty = false;
-      while (startIndex < cats.length) {
-        const categoryToLoad = cats[startIndex];
+      for (let i = 0; i < cats.length; i++) {
+        const categoryToLoad = cats[i];
         const stack = await getDiscoveryStack(categoryToLoad);
         if (stack.length > 0) {
           setActiveCategory(categoryToLoad);
-          categoryIndexRef.current = startIndex;
+          categoryIndexRef.current = i;
           useDiscoveryStore.getState().setStack(
             stack.map((r) => ({ ...r, imageUrl: `/api/recipes/${r.id}/hero` }))
           );
+          stackIsLoadedRef.current = true;
           foundNonEmpty = true;
           break;
         }
-        startIndex++;
       }
       if (!foundNonEmpty) {
         setActiveCategory(null);
+        categoryIndexRef.current = 0;
         useDiscoveryStore.getState().setStack([]);
+        stackIsLoadedRef.current = true;
       }
     } catch (error) {
       console.error('Failed to fetch discovery data', error);
@@ -82,14 +83,16 @@ export default function DiscoveryPage() {
           const index = cats.indexOf(targetCategory);
           const resolvedIndex = index !== -1 ? index : 0;
 
-          let startIndex = resolvedIndex;
+          // Wrap-around scan: start from resolvedIndex, cycle through all
+          // categories so earlier ones aren't skipped if a nudge pointed mid-list.
           let foundNonEmpty = false;
-          while (startIndex < cats.length && !ignore) {
-            const categoryToLoad = cats[startIndex];
+          for (let i = 0; i < cats.length && !ignore; i++) {
+            const tryIndex = (resolvedIndex + i) % cats.length;
+            const categoryToLoad = cats[tryIndex];
             const stack = await getDiscoveryStack(categoryToLoad);
             if (ignore) break;
             if (stack.length > 0) {
-              categoryIndexRef.current = startIndex;
+              categoryIndexRef.current = tryIndex;
               setActiveCategory(categoryToLoad);
               useDiscoveryStore.getState().setStack(
                 stack.map((r) => ({ ...r, imageUrl: `/api/recipes/${r.id}/hero` }))
@@ -98,7 +101,6 @@ export default function DiscoveryPage() {
               foundNonEmpty = true;
               break;
             }
-            startIndex++;
           }
           if (!foundNonEmpty && !ignore) {
             setActiveCategory(null);
@@ -131,11 +133,14 @@ export default function DiscoveryPage() {
 
   const loadNextCategory = useCallback(async () => {
     const cats = categoriesRef.current;
-    let nextIndex = categoryIndexRef.current + 1;
+    const startIndex = categoryIndexRef.current;
 
     setIsLoading(true);
     try {
-      while (nextIndex < cats.length) {
+      // Wrap-around scan: try every other category before declaring exhaustion.
+      // cats.length - 1 iterations skips the current index (already exhausted).
+      for (let i = 1; i < cats.length; i++) {
+        const nextIndex = (startIndex + i) % cats.length;
         const nextCategory = cats[nextIndex];
         const stack = await getDiscoveryStack(nextCategory);
         if (stack.length > 0) {
@@ -148,9 +153,8 @@ export default function DiscoveryPage() {
           setActiveCategory(nextCategory);
           return;
         }
-        nextIndex++;
       }
-      // All remaining categories exhausted → show empty state
+      // All categories exhausted → show empty state
       setActiveCategory(null);
       categoryIndexRef.current = 0;
       useDiscoveryStore.getState().setStack([]);

--- a/pwa/src/app/(app)/discovery/page.tsx
+++ b/pwa/src/app/(app)/discovery/page.tsx
@@ -38,19 +38,29 @@ export default function DiscoveryPage() {
       const cats = await getCategories();
       setCategories(cats);
       categoriesRef.current = cats;
+      setCurrentCategoryIndex(0);
+      categoryIndexRef.current = 0;
 
-      const targetCategory = cats[0];
-      if (targetCategory) {
-        setActiveCategory(targetCategory);
-        setCurrentCategoryIndex(0);
-        categoryIndexRef.current = 0;
-        const stack = await getDiscoveryStack(targetCategory);
-        useDiscoveryStore.getState().setStack(
-          stack.map((r) => ({
-            ...r,
-            imageUrl: `/api/recipes/${r.id}/hero`,
-          }))
-        );
+      let startIndex = 0;
+      let foundNonEmpty = false;
+      while (startIndex < cats.length) {
+        const categoryToLoad = cats[startIndex];
+        const stack = await getDiscoveryStack(categoryToLoad);
+        if (stack.length > 0) {
+          setActiveCategory(categoryToLoad);
+          setCurrentCategoryIndex(startIndex);
+          categoryIndexRef.current = startIndex;
+          useDiscoveryStore.getState().setStack(
+            stack.map((r) => ({ ...r, imageUrl: `/api/recipes/${r.id}/hero` }))
+          );
+          foundNonEmpty = true;
+          break;
+        }
+        startIndex++;
+      }
+      if (!foundNonEmpty) {
+        setActiveCategory(null);
+        useDiscoveryStore.getState().setStack([]);
       }
     } catch (error) {
       console.error('Failed to fetch discovery data', error);
@@ -77,21 +87,29 @@ export default function DiscoveryPage() {
         if (targetCategory) {
           const index = cats.indexOf(targetCategory);
           const resolvedIndex = index !== -1 ? index : 0;
-          setCurrentCategoryIndex(resolvedIndex);
-          categoryIndexRef.current = resolvedIndex;
-          setActiveCategory(targetCategory);
 
-          const stack = await getDiscoveryStack(targetCategory);
-          if (!ignore) {
-            useDiscoveryStore.getState().setStack(
-              stack.map((r) => ({
-                ...r,
-                imageUrl: `/api/recipes/${r.id}/hero`,
-              }))
-            );
+          let startIndex = resolvedIndex;
+          let foundNonEmpty = false;
+          while (startIndex < cats.length && !ignore) {
+            const categoryToLoad = cats[startIndex];
+            const stack = await getDiscoveryStack(categoryToLoad);
+            if (ignore) break;
+            if (stack.length > 0) {
+              setCurrentCategoryIndex(startIndex);
+              categoryIndexRef.current = startIndex;
+              setActiveCategory(categoryToLoad);
+              useDiscoveryStore.getState().setStack(
+                stack.map((r) => ({ ...r, imageUrl: `/api/recipes/${r.id}/hero` }))
+              );
+              stackIsLoadedRef.current = true;
+              foundNonEmpty = true;
+              break;
+            }
+            startIndex++;
+          }
+          if (!foundNonEmpty && !ignore) {
+            useDiscoveryStore.getState().setStack([]);
             stackIsLoadedRef.current = true;
-            // The fillTheGapVersion effect has recipes.length as a dep — it will
-            // re-fire now that the stack is populated and handle any pending SSE.
           }
         }
       } catch (error) {
@@ -115,6 +133,37 @@ export default function DiscoveryPage() {
     setHasPendingCards(recipes.length > 0);
     return () => setHasPendingCards(false);
   }, [recipes.length, setHasPendingCards]);
+
+  const loadNextCategory = useCallback(async () => {
+    const cats = categoriesRef.current;
+    let nextIndex = categoryIndexRef.current + 1;
+
+    setIsLoading(true);
+    try {
+      while (nextIndex < cats.length) {
+        const nextCategory = cats[nextIndex];
+        const stack = await getDiscoveryStack(nextCategory);
+        if (stack.length > 0) {
+          const mappedStack = stack.map((r) => ({
+            ...r,
+            imageUrl: `/api/recipes/${r.id}/hero`,
+          }));
+          useDiscoveryStore.getState().setStack(mappedStack);
+          setCurrentCategoryIndex(nextIndex);
+          categoryIndexRef.current = nextIndex;
+          setActiveCategory(nextCategory);
+          return;
+        }
+        nextIndex++;
+      }
+      // All remaining categories exhausted → show empty state
+      useDiscoveryStore.getState().setStack([]);
+    } catch (error) {
+      console.error('Failed to fetch next category stack', error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [setActiveCategory]);
 
   /**
    * Silent refetch of the current category stack triggered by fill-the-gap
@@ -154,6 +203,12 @@ export default function DiscoveryPage() {
         }
       }
 
+      // If SSE-driven removals emptied the category, advance to the next one
+      if (useDiscoveryStore.getState().discoveryStack.length === 0) {
+        loadNextCategory();
+        return;
+      }
+
       // Show micro-badge if any visible card was removed
       if (removedFromVisible) {
         setShowJustPlannedBadge(true);
@@ -165,7 +220,7 @@ export default function DiscoveryPage() {
     } catch (error) {
       console.error('Silent refetch of discovery category failed', error);
     }
-  }, []); // stable — reads from refs, no closure deps
+  }, [loadNextCategory]); // loadNextCategory is stable (ref-based)
 
   // Subscribe to fill-the-gap invalidation signal from SSE.
   // recipes.length is included so the effect re-fires once the stack loads,
@@ -186,30 +241,6 @@ export default function DiscoveryPage() {
       if (justPlannedTimerRef.current) clearTimeout(justPlannedTimerRef.current);
     };
   }, []);
-
-  const loadNextCategory = useCallback(async () => {
-    const nextIndex = currentCategoryIndex + 1;
-    if (nextIndex < categories.length) {
-      setIsLoading(true);
-      try {
-        const nextCategory = categories[nextIndex];
-        const stack = await getDiscoveryStack(nextCategory);
-        console.log('loadNextCategory rawStack first:', JSON.stringify(stack[0]));
-        const mappedStack = stack.map((r) => ({
-          ...r,
-          imageUrl: `/api/recipes/${r.id}/hero`,
-        }));
-        console.log('loadNextCategory mappedStack first:', JSON.stringify(mappedStack[0]));
-        useDiscoveryStore.getState().setStack(mappedStack);
-        setCurrentCategoryIndex(nextIndex);
-        setActiveCategory(nextCategory);
-      } catch (error) {
-        console.error('Failed to fetch next category stack', error);
-      } finally {
-        setIsLoading(false);
-      }
-    }
-  }, [categories, currentCategoryIndex, setActiveCategory]);
 
   const triggerEureka = useCallback(() => {
     const duration = 3 * 1000;
@@ -408,15 +439,19 @@ export default function DiscoveryPage() {
           <div className="text-2xl">✕</div>
         </button>
 
-        <button
-          type="button"
-          onClick={fetchCategories}
-          data-testid="refresh-button"
-          aria-label="Refresh recipe suggestions"
-          className="flex h-12 w-12 items-center justify-center rounded-full bg-white/50 text-charcoal/30 shadow-sm border border-charcoal/5 active:rotate-180 transition-transform duration-500"
-        >
-          <RefreshCcw size={18} />
-        </button>
+        {recipes.length === 0 ? (
+          <button
+            type="button"
+            onClick={fetchCategories}
+            data-testid="refresh-button"
+            aria-label="Refresh recipe suggestions"
+            className="flex h-12 w-12 items-center justify-center rounded-full bg-white/50 text-charcoal/30 shadow-sm border border-charcoal/5 active:rotate-180 transition-transform duration-500"
+          >
+            <RefreshCcw size={18} />
+          </button>
+        ) : (
+          <div className="h-12 w-12" />
+        )}
 
         <button
           type="button"


### PR DESCRIPTION
Users landing on discovery would see an empty state immediately if the first
category stack was empty, even when other categories had unvoted recipes.
The refresh button in the control bar also allowed bypassing category cycling.

- loadNextCategory loops through remaining categories (using refs, no stale
  closures), skipping empty stacks instead of stopping at the first empty one
- initialize() and fetchCategories() both cycle from their start index to find
  the first non-empty category instead of loading index 0 unconditionally
- refetchCurrentCategory (SSE fill-the-gap) calls loadNextCategory when the
  diff removes the last card from the current category stack
- Control bar refresh button is hidden while voting categories are available;
  it only appears alongside the empty-state card when all categories are exhausted

Adds five E2E tests covering the new cycling behavior.

https://claude.ai/code/session_01P3REnWemrgGFSpAGm1E1r5